### PR TITLE
When merging two suppliers, transfer all refund invoices FEXPND-9 #resolve

### DIFF
--- a/expenditure-tracking/src/main/java/pt/ist/expenditureTrackingSystem/domain/organization/Supplier.java
+++ b/expenditure-tracking/src/main/java/pt/ist/expenditureTrackingSystem/domain/organization/Supplier.java
@@ -420,7 +420,7 @@ public class Supplier extends Supplier_Base /* implements Indexable, Searchable 
             getAcquisitionsAfterTheFactSet().addAll(acquisitionAfterTheFacts);
             acquisitionAfterTheFacts.clear();
 
-            final Set<RefundableInvoiceFile> refundInvoices = supplier.getActiveRefundInvoicesSet();
+            final Set<RefundableInvoiceFile> refundInvoices = supplier.getRefundInvoicesSet();
             getRefundInvoicesSet().addAll(refundInvoices);
             refundInvoices.clear();
 


### PR DESCRIPTION
 When merging two suppliers, transfer all refund invoices instead of just archived invoices.