### PR TITLE
Do not restore debt twice when canceling/rejecting a transaction FEXPND-24 #resolve

### DIFF
--- a/working-capital/src/main/java/module/workingCapital/domain/WorkingCapitalTransaction.java
+++ b/working-capital/src/main/java/module/workingCapital/domain/WorkingCapitalTransaction.java
@@ -174,7 +174,9 @@ public class WorkingCapitalTransaction extends WorkingCapitalTransaction_Base {
     }
 
     protected void restoreDebtOfFollowingTransactions() {
-        restoreDebtOfFollowingTransactions(getValue(), getValue());
+        if (!isCanceledOrRejected()) {
+            restoreDebtOfFollowingTransactions(getValue(), getValue());
+        }
     }
 
     public void reject(User loggedPerson) {


### PR DESCRIPTION
Do not restore debt when canceling/rejecting a transaction that was already rejected/canceled